### PR TITLE
Bugs fixed, feature ready to be merged! 

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,14 +1,10 @@
 import { type NextFunction, type Request, type Response } from 'express';
 import { userService, type UserService } from '../services/user.service';
-import {
-    type PathParamUserDto,
-    type PathParamUserMeetingDto,
-    UserUpdateDto
-} from '../dtos/user.dto';
+import { type PathParamUserDto, type PathParamUserMeetingDto, UserUpdateDto } from '../dtos/user.dto';
 
 import { plainToClass } from 'class-transformer';
 import { validateDto } from '../handlers/validate-request.handler';
-import { MeetingDto, MeetingUpdateDto, ReqQueryFilterMeetings, StatusUpdateDto } from '../dtos/meeting.dto';
+import { MeetingCreateDto, MeetingUpdateDto, ReqQueryFilterMeetings, StatusUpdateDto } from '../dtos/meeting.dto';
 import { userManager, type UserManager } from '../managers/user.manager';
 import createHttpError from 'http-errors';
 
@@ -63,15 +59,15 @@ export class UserController {
         }
     }
 
-    async createMeeting (req: Request<PathParamUserDto, {}, MeetingDto>, res: Response, next: NextFunction): Promise<Response | void> {
+    async createMeeting (req: Request<PathParamUserDto, {}, MeetingCreateDto>, res: Response, next: NextFunction): Promise<Response | void> {
         // Transform request body to MeetingDto Class
-        const meetingDto = plainToClass(MeetingDto, req.body, { excludeExtraneousValues: true });
+        const meetingCrateDto = plainToClass(MeetingCreateDto, req.body, { excludeExtraneousValues: true });
 
         try {
             // Validate MeetingDto
-            await validateDto(meetingDto);
-            meetingDto.creator = req.params.username;
-            const createdMeeting = await this.userManager.createMeeting(meetingDto);
+            await validateDto(meetingCrateDto);
+            meetingCrateDto.creator = req.params.username;
+            const createdMeeting = await this.userManager.createMeeting(meetingCrateDto);
             return res.status(201).json(createdMeeting);
         } catch (err: unknown) {
             next(err);

--- a/src/dtos/meeting.dto.ts
+++ b/src/dtos/meeting.dto.ts
@@ -2,15 +2,13 @@ import { AutoMap } from '@automapper/classes';
 import { Expose } from 'class-transformer';
 import { IsArray, IsDateString, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { Answered, type Period, Repeated } from '../types/enums';
-import { type Participant } from '../sub-entities/Participant.sub-entity';
+import { Participant } from '../sub-entities/Participant.sub-entity';
+import { Creator } from '../sub-entities/Creator.sub-entity';
 
-export class MeetingDto {
+abstract class BaseMeetingDto {
     @IsOptional()
     @AutoMap()
         _id?: string;
-
-    @IsString({ message: 'Creator must be of type string!' })
-        creator!: string;
 
     @IsString({ message: 'Meeting room must be of type string!' })
     @IsNotEmpty({ message: 'Meeting room is required!' })
@@ -30,11 +28,6 @@ export class MeetingDto {
     @AutoMap()
         endTime!: Date;
 
-    @IsArray({ message: 'Participants must be of type Array!' })
-    @IsOptional()
-    @Expose()
-        participants?: string[];
-
     @IsOptional()
     @IsEnum(Repeated, { message: 'Repeated must be one of the following: daily, weekly, monthly, (default: no)' })
     @Expose()
@@ -42,7 +35,40 @@ export class MeetingDto {
         repeated: Repeated = Repeated.NO;
 }
 
-export class MeetingUpdateDto implements Partial<MeetingDto> {
+export class MeetingCreateDto extends BaseMeetingDto {
+    creator!: string;
+
+    @IsArray({ message: 'Participants must be of type Array!' })
+    @IsOptional()
+    @Expose()
+        participants?: string[];
+}
+
+export class MeetingDto extends BaseMeetingDto {
+    @IsOptional()
+    @AutoMap()
+        _id!: string;
+
+    @AutoMap(() => Creator)
+        creator!: Creator;
+
+    @AutoMap()
+        meetingRoom!: string;
+
+    @AutoMap()
+        startTime!: Date;
+
+    @AutoMap()
+        endTime!: Date;
+
+    @AutoMap(() => [Participant])
+        participants!: Participant[];
+
+    @AutoMap()
+        repeated!: Repeated;
+}
+
+export class MeetingUpdateDto implements Partial<MeetingCreateDto> {
     @IsOptional()
     @AutoMap()
         _id?: string;

--- a/src/entities/meeting.entity.ts
+++ b/src/entities/meeting.entity.ts
@@ -1,14 +1,15 @@
 import { Types } from 'mongoose';
 import { AutoMap } from '@automapper/classes';
 import { Repeated } from '../types/enums';
-import { type Participant } from '../sub-entities/Participant.sub-entity';
-import { type Creator } from '../sub-entities/Creator.sub-entity';
+import { Participant } from '../sub-entities/Participant.sub-entity';
+import { Creator } from '../sub-entities/Creator.sub-entity';
 
 export class MeetingEntity {
     @AutoMap()
         _id!: Types.ObjectId;
 
-    creator!: Creator;
+    @AutoMap(() => Creator)
+        creator!: Creator;
 
     @AutoMap()
         meetingRoom!: string;
@@ -19,8 +20,9 @@ export class MeetingEntity {
     @AutoMap()
         endTime!: Date;
 
-    participants?: Participant[];
+    @AutoMap(() => [Participant])
+        participants?: Participant[];
 
     @AutoMap()
-        repeated: Repeated = Repeated.NO;
+        repeated?: Repeated = Repeated.NO;
 }

--- a/src/handlers/validate-datetimes.handler.ts
+++ b/src/handlers/validate-datetimes.handler.ts
@@ -1,5 +1,5 @@
 import { DateTime, Interval } from 'luxon';
-import { type MeetingDto } from '../dtos/meeting.dto';
+import { type MeetingCreateDto, type MeetingDto } from '../dtos/meeting.dto';
 
 export function validateTimesHHMM (start: string, end: string): boolean {
     const now = DateTime.now();
@@ -10,7 +10,7 @@ export function validateTimesHHMM (start: string, end: string): boolean {
     return startTime < endTime;
 }
 
-export function hasConflictInHours (existing: MeetingDto, meeting: MeetingDto): boolean {
+export function hasConflictInHours (existing: MeetingDto | MeetingCreateDto, meeting: MeetingDto | MeetingCreateDto): boolean {
     // Extract Hours and Minutes from all 4 dates
     const existingStartTime = DateTime.fromJSDate(new Date(existing.startTime)).toFormat('HH:mm');
     const existingEndTime = DateTime.fromJSDate(new Date(existing.endTime)).toFormat('HH:mm');
@@ -34,7 +34,7 @@ export function hasConflictInHours (existing: MeetingDto, meeting: MeetingDto): 
     return interval.contains(meetingStart) || interval.contains(meetingEnd);
 }
 
-export function hasConflictInHoursWeekly (existing: MeetingDto, meeting: MeetingDto): boolean {
+export function hasConflictInHoursWeekly (existing: MeetingDto | MeetingCreateDto, meeting: MeetingDto | MeetingCreateDto): boolean {
     const existingDay = DateTime.fromJSDate(new Date(existing.startTime)).get('weekday');
     const meetingDay = DateTime.fromJSDate(new Date(existing.startTime)).get('weekday');
 
@@ -45,7 +45,7 @@ export function hasConflictInHoursWeekly (existing: MeetingDto, meeting: Meeting
     return false;
 }
 
-export function hasConflictInHoursMonthly (existing: MeetingDto, meeting: MeetingDto): boolean {
+export function hasConflictInHoursMonthly (existing: MeetingDto | MeetingCreateDto, meeting: MeetingDto | MeetingCreateDto): boolean {
     const existingDay = DateTime.fromJSDate(new Date(existing.startTime)).get('day');
     const meetingDay = DateTime.fromJSDate(new Date(existing.startTime)).get('day');
 
@@ -56,7 +56,7 @@ export function hasConflictInHoursMonthly (existing: MeetingDto, meeting: Meetin
     return false;
 }
 
-export function meetingsInConflict (meeting: MeetingDto, existing: MeetingDto): boolean {
+export function meetingsInConflict (meeting: MeetingDto | MeetingCreateDto, existing: MeetingDto): boolean {
     const existingStart = DateTime.fromJSDate(new Date(existing.startTime));
     const existingEnd = DateTime.fromJSDate(new Date(existing.endTime));
     const existingInterval = Interval.fromDateTimes(existingStart, existingEnd);

--- a/src/managers/user.manager.ts
+++ b/src/managers/user.manager.ts
@@ -1,6 +1,6 @@
 import createHttpError, { HttpError } from 'http-errors';
 import { meetingService, type MeetingService } from '../services/meeting.service';
-import { type MeetingDto, type MeetingUpdateDto, type StatusUpdateDto } from '../dtos/meeting.dto';
+import { type MeetingCreateDto, type MeetingDto, type MeetingUpdateDto, type StatusUpdateDto } from '../dtos/meeting.dto';
 import { userService, type UserService } from '../services/user.service';
 import { DateTime, Interval } from 'luxon';
 import { meetingRoomService, type MeetingRoomService } from '../services/meeting-room.service';
@@ -15,6 +15,7 @@ import { type UserDto } from '../dtos/user.dto';
 import { toUserMeetingFull } from '../mappers/userMeeting.mapper';
 import { Answered, Period, Repeated } from '../types/enums';
 import { UserMeeting, type UserMeetingFull } from '../sub-entities/user-meeting.sub-entity';
+import { Participant } from '../sub-entities/Participant.sub-entity';
 
 function validateRoomCapacity (meetingDto: MeetingDto | MeetingUpdateDto, room: MeetingRoomDto): void {
     if (meetingDto.participants?.length && meetingDto.participants.length > room.capacity - 1) {
@@ -173,19 +174,19 @@ export class UserManager {
         return await this.meetingService.findById(meetingId);
     }
 
-    async createMeeting (meetingDto: MeetingDto): Promise<MeetingDto> {
+    async createMeeting (meetingCreateDto: MeetingCreateDto): Promise<MeetingDto> {
         // Is Creator existing? If yes => store in variable and use below; If no => userService method will throw error, which will be handled by Controller
-        const creator = await this.userService.findByUsername(meetingDto.creator);
+        const creator = await this.userService.findByUsername(meetingCreateDto.creator);
 
         // Is Meeting Room existing? If yes => store in variable and use below; If no => meetingRoomService method will throw error, which will be handled by Controller
-        const room = await this.meetingRoomService.findByName(meetingDto.meetingRoom);
+        const room = await this.meetingRoomService.findByName(meetingCreateDto.meetingRoom);
 
         // Check if new meeting participants + creator does not exceed Meeting Room's capacity?
-        validateRoomCapacity(meetingDto, room);
+        validateRoomCapacity(meetingCreateDto, room);
 
         // Transform new meeting start and end times to Luxon object DateTime and use variables below
-        const meetingStart = DateTime.fromJSDate(new Date(meetingDto.startTime));
-        const meetingEnd = DateTime.fromJSDate(new Date(meetingDto.endTime));
+        const meetingStart = DateTime.fromJSDate(new Date(meetingCreateDto.startTime));
+        const meetingEnd = DateTime.fromJSDate(new Date(meetingCreateDto.endTime));
 
         // Make interval from room available hours in format HH:mm
         const roomInterval = constructRoomInterval(room, meetingStart, meetingEnd);
@@ -200,32 +201,32 @@ export class UserManager {
         validateWithinSameDay(meetingStart, meetingEnd);
 
         // Participants Validation:
-        await this.validateParticipants(meetingDto, creator);
+        await this.validateParticipants(meetingCreateDto, creator);
 
         // Check for conflict meetings in Creator!
-        switch (meetingDto.repeated) {
+        switch (meetingCreateDto.repeated) {
             case Repeated.DAILY:
-                await this.validateCreatorMeetingsConflictDaily(creator, meetingDto);
+                await this.validateCreatorMeetingsConflictDaily(creator, meetingCreateDto);
                 break;
             case Repeated.WEEKLY:
-                await this.validateCreatorMeetingsConflictWeekly(creator, meetingDto);
+                await this.validateCreatorMeetingsConflictWeekly(creator, meetingCreateDto);
                 break;
             case Repeated.MONTHLY:
-                await this.validateCreatorMeetingsConflictMonthly(creator, meetingDto);
+                await this.validateCreatorMeetingsConflictMonthly(creator, meetingCreateDto);
                 break;
             default:
-                await this.validateCreatorMeetingsConflictNonRepeating(creator, meetingDto);
+                await this.validateCreatorMeetingsConflictNonRepeating(creator, meetingCreateDto);
                 break;
         }
 
         // Map Creator username to meeting Dto
-        meetingDto.creator = creator.username;
+        meetingCreateDto.creator = creator.username;
 
         // Create the meeting!
-        const createdMeeting = await this.meetingService.create(meetingDto);
+        const createdMeeting = await this.meetingService.create(meetingCreateDto);
 
         // Construct UserMeeting Key
-        const meetingKey = meetingDto.repeated && meetingDto.repeated !== Repeated.NO ? meetingDto.repeated : DateTime.fromJSDate(new Date(createdMeeting.startTime)).toFormat('dd-MM-yyyy');
+        const meetingKey = meetingCreateDto.repeated && meetingCreateDto.repeated !== Repeated.NO ? meetingCreateDto.repeated : DateTime.fromJSDate(new Date(createdMeeting.startTime)).toFormat('dd-MM-yyyy');
 
         const newUserMeeting = new UserMeeting();
 
@@ -238,7 +239,7 @@ export class UserManager {
         await this.addUserMeetingToCreator(newUserMeeting, creator, meetingKey);
 
         // Add meeting to participants
-        await this.addUserMeetingToParticipants(newUserMeeting, meetingDto, meetingKey);
+        await this.addUserMeetingToParticipants(newUserMeeting, meetingCreateDto, meetingKey);
 
         return createdMeeting;
     }
@@ -313,19 +314,23 @@ export class UserManager {
             dummy.endTime = meetingUpdateDto.endTime;
         }
 
-        const creator = await this.userService.findByUsername(existing.creator);
+        const creator = await this.userService.findByUsername(existing.creator.username);
         meetingUpdateDto.creator = creator.username;
 
         // 5. Participants:
         if (meetingUpdateDto.participants) {
             // Concat existing participants and newly added ones!
             const newParticipants = meetingUpdateDto.participants;
-            const allParticipants = existing.participants?.concat(meetingUpdateDto.participants);
+            const allParticipants = existing.participants?.concat(meetingUpdateDto.participants.map((username) => {
+                const newParticipant = new Participant();
+                newParticipant.username = username;
+                return newParticipant;
+            }));
 
             // 5.1: Check if all are existing participants' usernames
             // 5.2: Check for duplicates
             // 5.3: Check if creator is in participants
-            meetingUpdateDto.participants = allParticipants;
+            meetingUpdateDto.participants = allParticipants.map((part) => part.username);
             await this.validateParticipants(meetingUpdateDto, creator);
 
             // Populate meetings to new participants!
@@ -335,9 +340,13 @@ export class UserManager {
             meetingUpdateDto.participants = newParticipants;
             await this.addUserMeetingToParticipants(userMeeting, meetingUpdateDto, meetingKey);
 
-            meetingUpdateDto.participants = allParticipants;
+            meetingUpdateDto.participants = allParticipants.map((part) => part.username);
             // If new participants are valid, append them to DUMMY also
-            dummy.participants = meetingUpdateDto.participants;
+            dummy.participants = meetingUpdateDto.participants.map((username) => {
+                const newPart = new Participant();
+                newPart.username = username;
+                return newPart;
+            });
         }
 
         // 2.3: Is Capacity Exceeded? => Check after participants
@@ -372,7 +381,7 @@ export class UserManager {
             // Remove UserMeeting from each Participant
             if (updated.participants) {
                 for (const participantUsername of updated.participants) {
-                    const participant = await this.userService.findByUsername(participantUsername);
+                    const participant = await this.userService.findByUsername(participantUsername.username);
                     await this.removeUserMeeting(oldMeetingKey, participant, id);
                 }
             }
@@ -395,7 +404,7 @@ export class UserManager {
         // Delete meeting from meetings
         const deleted = await this.meetingService.delete(id);
 
-        const creator = await this.userService.findByUsername(deleted.creator);
+        const creator = await this.userService.findByUsername(deleted.creator.username);
         const oldMeetingKey = deleted.repeated !== Repeated.NO ? deleted.repeated : DateTime.fromJSDate(new Date(deleted.startTime)).toFormat('dd-MM-yyyy');
 
         // Remove UserMeetings from creator
@@ -407,15 +416,15 @@ export class UserManager {
         // Remove UserMeetings from participants
         if (deleted.participants) {
             for (const participantUsername of deleted.participants) {
-                const participant = await this.userService.findByUsername(participantUsername);
+                const participant = await this.userService.findByUsername(participantUsername.username);
                 await this.removeUserMeeting(oldMeetingKey, participant, deleted._id);
             }
         }
         return deleted;
     }
 
-    async updateStatus (usernme: string, meetingId: string, statusUpdateDto: StatusUpdateDto): Promise<UserDto> {
-        const user = await this.userService.findByUsername(usernme);
+    async updateStatus (username: string, meetingId: string, statusUpdateDto: StatusUpdateDto): Promise<UserDto> {
+        const user = await this.userService.findByUsername(username);
         // Find user meeting
         let userMeeting;
         for (const meetingsKey in user.meetings) {
@@ -445,24 +454,41 @@ export class UserManager {
                     break;
             }
         }
+
         if (!userMeeting) {
             throw new createHttpError.NotFound('No such User Meeting found!');
         }
         userMeeting.answered = statusUpdateDto.answered;
-        return await this.userService.update(usernme, user);
+        const updated = await this.userService.update(username, user);
+
+        // TODO: Update Participant and Creator in Meeting also!
+        // const meeting = await this.meetingService.findById(meetingId);
+        // if (meeting.creator === username) {
+        //     const creator = new Creator();
+        //     creator.username = username;
+        //     creator.answered = statusUpdateDto.answered;
+        // }
+
+        return updated;
     }
 
-    private async addUserMeetingToParticipants (newUserMeeting: UserMeeting, meetingDto: MeetingDto | MeetingUpdateDto, meetingKey: string): Promise<void> {
+    private async addUserMeetingToParticipants (newUserMeeting: UserMeeting, meetingDto: MeetingDto | MeetingCreateDto | MeetingUpdateDto, meetingKey: string): Promise<void> {
         newUserMeeting.answered = Answered.PENDING;
         if (meetingDto.participants) {
-            for (const participantUsername of meetingDto.participants) {
-                const participant = await this.userService.findByUsername(participantUsername);
-                if (!Object.keys(participant.meetings as Object).includes(meetingKey)) {
-                    participant.meetings[meetingKey] = new Array<UserMeeting>();
+            for (const participant of meetingDto.participants) {
+                let username;
+                if (typeof participant === 'string') {
+                    username = participant;
+                } else {
+                    username = participant.username;
                 }
-                participant.meetings[meetingKey].push(newUserMeeting);
-                if (participant._id) {
-                    await this.userService.update(participant.username, participant);
+                const user = await this.userService.findByUsername(username);
+                if (!Object.keys(user.meetings as Object).includes(meetingKey)) {
+                    user.meetings[meetingKey] = new Array<UserMeeting>();
+                }
+                user.meetings[meetingKey].push(newUserMeeting);
+                if (user._id) {
+                    await this.userService.update(username, user);
                 }
             }
         }
@@ -480,7 +506,7 @@ export class UserManager {
         await this.userService.update(creator.username, creator);
     }
 
-    private async validateCreatorMeetingsConflictNonRepeating (creator: UserDto, meetingDto: MeetingDto, meetingId: string = 'some-invalid-username!'): Promise<void> {
+    private async validateCreatorMeetingsConflictNonRepeating (creator: UserDto, meetingDto: MeetingDto | MeetingCreateDto, meetingId: string = 'some-invalid-username!'): Promise<void> {
         const newMeetingStart = DateTime.fromJSDate(new Date(meetingDto.startTime));
         for (const meetingKey in creator.meetings) {
             switch (meetingKey) {
@@ -558,7 +584,7 @@ export class UserManager {
         }
     }
 
-    private async validateCreatorMeetingsConflictDaily (creator: UserDto, meetingDto: MeetingDto, meetingId: string = 'some-invalid-username!'): Promise<void> {
+    private async validateCreatorMeetingsConflictDaily (creator: UserDto, meetingDto: MeetingDto | MeetingCreateDto, meetingId: string = 'some-invalid-username!'): Promise<void> {
         const newMeetingStart = DateTime.fromJSDate(new Date(meetingDto.startTime));
         for (const meetingKey in creator.meetings) {
             if (meetingKey === Repeated.NO || undefined) {
@@ -591,7 +617,7 @@ export class UserManager {
         }
     }
 
-    private async validateCreatorMeetingsConflictWeekly (creator: UserDto, meetingDto: MeetingDto, meetingId: string = 'some-invalid-username!'): Promise<void> {
+    private async validateCreatorMeetingsConflictWeekly (creator: UserDto, meetingDto: MeetingDto | MeetingCreateDto, meetingId: string = 'some-invalid-username!'): Promise<void> {
         const newMeetingStart = DateTime.fromJSDate(new Date(meetingDto.startTime));
         for (const meetingKey in creator.meetings) {
             switch (meetingKey) {
@@ -659,7 +685,7 @@ export class UserManager {
         }
     }
 
-    private async validateCreatorMeetingsConflictMonthly (creator: UserDto, meetingDto: MeetingDto, meetingId: string = 'some-invalid-username!'): Promise<void> {
+    private async validateCreatorMeetingsConflictMonthly (creator: UserDto, meetingDto: MeetingDto | MeetingCreateDto, meetingId: string = 'some-invalid-username!'): Promise<void> {
         const newMeetingStart = DateTime.fromJSDate(new Date(meetingDto.startTime));
         for (const meetingKey in creator.meetings) {
             switch (meetingKey) {
@@ -728,7 +754,7 @@ export class UserManager {
         }
     }
 
-    private async validateParticipants (meetingDto: MeetingDto | MeetingUpdateDto, creator: UserDto): Promise<void> {
+    private async validateParticipants (meetingDto: MeetingCreateDto | MeetingUpdateDto, creator: UserDto): Promise<void> {
         if (meetingDto.participants && meetingDto.participants.length > 0) {
             try {
                 for (const participant of meetingDto.participants) {

--- a/src/mappers/meeting.mapper.ts
+++ b/src/mappers/meeting.mapper.ts
@@ -10,7 +10,7 @@ import {
 import { classes } from '@automapper/classes';
 import { Types } from 'mongoose';
 import { MeetingEntity } from '../entities/meeting.entity';
-import { MeetingDto, MeetingUpdateDto } from '../dtos/meeting.dto';
+import { MeetingCreateDto, MeetingDto, MeetingUpdateDto } from '../dtos/meeting.dto';
 import { Creator } from '../sub-entities/Creator.sub-entity';
 import { Participant } from '../sub-entities/Participant.sub-entity';
 
@@ -28,18 +28,16 @@ createMap(
     MeetingEntity,
     MeetingDto,
     typeConverter(Types.ObjectId, String, (objectId) => objectId.toString()),
-    forMember(
-        (dto) => dto.creator,
-        mapFrom((entity) => entity.creator.username)
+    forMember((dto) => dto.creator,
+        mapFrom((entity) => entity.creator)
     ),
-    forMember(
-        (dto) => dto.participants,
-        mapFrom((entity) => entity.participants ? entity.participants.map((p) => p.username) : undefined)
+    forMember((dto) => dto.participants,
+        mapFrom((entity) => entity.participants)
     )
 );
 createMap(
     mapper,
-    MeetingDto,
+    MeetingCreateDto,
     MeetingEntity,
     forMember(
         (entity) => entity.creator,
@@ -78,5 +76,5 @@ createMap(
 );
 
 export const toMeetingDto = (e: MeetingEntity): MeetingDto => mapper.map(e, MeetingEntity, MeetingDto);
-export const toMeetingEntity = (d: MeetingDto): MeetingEntity => mapper.map(d, MeetingDto, MeetingEntity);
+export const toMeetingEntity = (d: MeetingCreateDto): MeetingEntity => mapper.map(d, MeetingCreateDto, MeetingEntity);
 export const toMeetingEntityUpdate = (d: MeetingUpdateDto): MeetingEntity => mapper.map(d, MeetingUpdateDto, MeetingEntity);

--- a/src/mappers/meeting.mapper.ts
+++ b/src/mappers/meeting.mapper.ts
@@ -1,9 +1,7 @@
 import {
-    type Converter,
-    convertUsing,
     createMap,
     createMapper,
-    forMember,
+    forMember, ignore,
     mapFrom,
     typeConverter
 } from '@automapper/core';
@@ -11,18 +9,44 @@ import { classes } from '@automapper/classes';
 import { Types } from 'mongoose';
 import { MeetingEntity } from '../entities/meeting.entity';
 import { MeetingCreateDto, MeetingDto, MeetingUpdateDto } from '../dtos/meeting.dto';
-import { Creator } from '../sub-entities/Creator.sub-entity';
 import { Participant } from '../sub-entities/Participant.sub-entity';
 
 const mapper = createMapper({ strategyInitializer: classes() });
 
-const creatorConverter: Converter<string, Object> = {
-    convert (source: string): Object {
-        const creator = new Creator();
-        creator.username = source;
-        return creator;
-    }
-};
+createMap(
+    mapper,
+    MeetingCreateDto,
+    MeetingDto,
+    forMember(
+        (dto) => dto._id, ignore()
+    ),
+    forMember(
+        (dto) => dto.participants,
+        mapFrom((updateDto) => updateDto.participants?.map((part) => {
+            const newPart = new Participant();
+            newPart.username = part;
+            return newPart;
+        }))
+    )
+);
+
+createMap(
+    mapper,
+    MeetingUpdateDto,
+    MeetingDto,
+    forMember(
+        (dto) => dto._id, ignore()
+    ),
+    forMember(
+        (dto) => dto.participants,
+        mapFrom((updateDto) => updateDto.participants?.map((part) => {
+            const newPart = new Participant();
+            newPart.username = part;
+            return newPart;
+        }))
+    )
+);
+
 createMap(
     mapper,
     MeetingEntity,
@@ -35,46 +59,21 @@ createMap(
         mapFrom((entity) => entity.participants)
     )
 );
-createMap(
-    mapper,
-    MeetingCreateDto,
-    MeetingEntity,
-    forMember(
-        (entity) => entity.creator,
-        convertUsing(creatorConverter, (dto) => dto.creator)
-    ),
-    forMember(
-        (entity) => entity.participants,
-        mapFrom((dto) => dto.participants
-            ? dto.participants.map((part) => {
-                const participant = new Participant();
-                participant.username = part;
-                return participant;
-            })
-            : undefined)
-    )
-);
 
 createMap(
     mapper,
-    MeetingUpdateDto,
+    MeetingDto,
     MeetingEntity,
-    forMember(
-        (entity) => entity.creator,
-        convertUsing(creatorConverter, (dto) => dto.creator)
+    typeConverter(Types.ObjectId, String, (objectId) => objectId.toString()),
+    forMember((dto) => dto.creator,
+        mapFrom((entity) => entity.creator)
     ),
-    forMember(
-        (entity) => entity.participants,
-        mapFrom((dto) => dto.participants
-            ? dto.participants.map((part) => {
-                const participant = new Participant();
-                participant.username = part;
-                return participant;
-            })
-            : undefined)
+    forMember((dto) => dto.participants,
+        mapFrom((entity) => entity.participants)
     )
 );
 
 export const toMeetingDto = (e: MeetingEntity): MeetingDto => mapper.map(e, MeetingEntity, MeetingDto);
-export const toMeetingEntity = (d: MeetingCreateDto): MeetingEntity => mapper.map(d, MeetingCreateDto, MeetingEntity);
-export const toMeetingEntityUpdate = (d: MeetingUpdateDto): MeetingEntity => mapper.map(d, MeetingUpdateDto, MeetingEntity);
+export const toMeetingEntity = (d: MeetingDto): MeetingEntity => mapper.map(d, MeetingDto, MeetingEntity);
+export const fromCreateToMeetingDto = (d: MeetingCreateDto): MeetingDto => mapper.map(d, MeetingCreateDto, MeetingDto);
+export const fromUpdateToMeetingDto = (d: MeetingUpdateDto): MeetingDto => mapper.map(d, MeetingUpdateDto, MeetingDto);

--- a/src/middlewares/guards.ts
+++ b/src/middlewares/guards.ts
@@ -7,7 +7,7 @@ import { validateDto } from '../handlers/validate-request.handler';
 import { type MeetingDto } from '../dtos/meeting.dto';
 
 function userExistsInMeeteing (username: string, meeting: MeetingDto): boolean {
-    return meeting.creator === username && !!(meeting.participants?.includes(username));
+    return meeting.creator.username === username && !!(meeting.participants?.map((part) => part.username).includes(username));
 }
 
 export function isLogged () {
@@ -78,7 +78,7 @@ export function isCreator () {
             // Validate request params object
             await validateDto(pathParams);
             const meeting = await meetingService.findById(req.params.meetingId);
-            if (meeting.creator === req.user?.username) {
+            if (meeting.creator.username === req.user?.username) {
                 next();
             } else {
                 next(createHttpError.Unauthorized('You are not authorised!'));

--- a/src/middlewares/guards.ts
+++ b/src/middlewares/guards.ts
@@ -7,7 +7,7 @@ import { validateDto } from '../handlers/validate-request.handler';
 import { type MeetingDto } from '../dtos/meeting.dto';
 
 function userExistsInMeeteing (username: string, meeting: MeetingDto): boolean {
-    return meeting.creator.username === username && !!(meeting.participants?.map((part) => part.username).includes(username));
+    return meeting.creator.username === username || !!(meeting.participants?.map((part) => part.username).includes(username));
 }
 
 export function isLogged () {

--- a/src/repositories/meeting.repository.ts
+++ b/src/repositories/meeting.repository.ts
@@ -1,8 +1,8 @@
 import { isValidObjectId, model, Schema } from 'mongoose';
 import { type BaseRepository } from './base.repository';
 import { type MeetingEntity } from '../entities/meeting.entity';
-import { type MeetingCreateDto, type MeetingUpdateDto } from '../dtos/meeting.dto';
-import { toMeetingEntity, toMeetingEntityUpdate } from '../mappers/meeting.mapper';
+import { type MeetingDto } from '../dtos/meeting.dto';
+import { toMeetingEntity } from '../mappers/meeting.mapper';
 import { Repeated } from '../types/enums';
 
 const meetingSchema = new Schema<MeetingEntity>({
@@ -48,8 +48,8 @@ const meetingSchema = new Schema<MeetingEntity>({
 
 const meetingModel = model<MeetingEntity>('Meeting', meetingSchema);
 
-export class MeetingRepository implements BaseRepository<MeetingEntity, MeetingCreateDto> {
-    async create (meetingDto: MeetingCreateDto): Promise<MeetingEntity> {
+export class MeetingRepository implements BaseRepository<MeetingEntity, MeetingDto> {
+    async create (meetingDto: MeetingDto): Promise<MeetingEntity> {
         const entity: MeetingEntity = toMeetingEntity(meetingDto);
         return await meetingModel.create(entity);
     }
@@ -65,11 +65,11 @@ export class MeetingRepository implements BaseRepository<MeetingEntity, MeetingC
         return await meetingModel.findById(id);
     }
 
-    async updateById (id: string, dto: MeetingUpdateDto): Promise<MeetingEntity | null> {
+    async updateById (id: string, dto: MeetingDto): Promise<MeetingEntity | null> {
         if (!isValidObjectId(id)) {
             return null;
         }
-        const entity = toMeetingEntityUpdate(dto);
+        const entity = toMeetingEntity(dto);
         return await meetingModel.findByIdAndUpdate(id, entity, { new: true });
     }
 

--- a/src/repositories/meeting.repository.ts
+++ b/src/repositories/meeting.repository.ts
@@ -1,7 +1,7 @@
 import { isValidObjectId, model, Schema } from 'mongoose';
 import { type BaseRepository } from './base.repository';
 import { type MeetingEntity } from '../entities/meeting.entity';
-import { type MeetingDto, type MeetingUpdateDto } from '../dtos/meeting.dto';
+import { type MeetingCreateDto, type MeetingUpdateDto } from '../dtos/meeting.dto';
 import { toMeetingEntity, toMeetingEntityUpdate } from '../mappers/meeting.mapper';
 import { Repeated } from '../types/enums';
 
@@ -48,8 +48,8 @@ const meetingSchema = new Schema<MeetingEntity>({
 
 const meetingModel = model<MeetingEntity>('Meeting', meetingSchema);
 
-export class MeetingRepository implements BaseRepository<MeetingEntity, MeetingDto> {
-    async create (meetingDto: MeetingDto): Promise<MeetingEntity> {
+export class MeetingRepository implements BaseRepository<MeetingEntity, MeetingCreateDto> {
+    async create (meetingDto: MeetingCreateDto): Promise<MeetingEntity> {
         const entity: MeetingEntity = toMeetingEntity(meetingDto);
         return await meetingModel.create(entity);
     }

--- a/src/services/meeting.service.ts
+++ b/src/services/meeting.service.ts
@@ -1,6 +1,6 @@
 import createHttpError from 'http-errors';
 import { meetingRepository, type MeetingRepository } from '../repositories/meeting.repository';
-import { type MeetingDto, type MeetingUpdateDto } from '../dtos/meeting.dto';
+import { type MeetingCreateDto, type MeetingDto, type MeetingUpdateDto } from '../dtos/meeting.dto';
 import { toMeetingDto } from '../mappers/meeting.mapper';
 
 export class MeetingService {
@@ -11,7 +11,7 @@ export class MeetingService {
         return meetings.map(toMeetingDto);
     }
 
-    async create (dto: MeetingDto): Promise<MeetingDto> {
+    async create (dto: MeetingCreateDto): Promise<MeetingDto> {
         const created = await this.meetingRepository.create(dto);
         return toMeetingDto(created);
     }


### PR DESCRIPTION
Apart from changing only the userMeeting of the user, updateStatus method now changes also the Creator/Participant property in Meeting (depending on what type of participant is the user in question). 

In order to achieve this, we had to refactor Meeting DTOs a bit, so that: 

- MeetingDto could be an exact replica of MeetingEntity; 
- Create/UpdateMeetingDto holds only Participants' usernames as Strings; 
- Create/UpdateMeetingDto holds only Participants and Creators as objects;
- Create/UpdateMeetingDto is now mapped to Meeting Entity;
- Client receives an UserMeetingFull object, which is a combination between MeetingDto and UserMeeting (so user can also see his "Answered" status when accessing meeting(s);